### PR TITLE
fix : security 버그수정

### DIFF
--- a/src/main/java/org/eDrink24/controller/login/JwtAuthenticationController.java
+++ b/src/main/java/org/eDrink24/controller/login/JwtAuthenticationController.java
@@ -1,18 +1,14 @@
 package org.eDrink24.controller.login;
 
 import lombok.extern.slf4j.Slf4j;
-import org.eDrink24.domain.customer.Customer;
 import org.eDrink24.dto.customer.CustomerDTO;
 import org.eDrink24.security.JwtTokenResponse;
 import org.eDrink24.security.JwtTokenService;
 import org.eDrink24.service.customer.AuthenticationService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,14 +20,14 @@ import java.util.Map;
 @Slf4j
 public class JwtAuthenticationController {
 
-    private JwtTokenService tokenService;
-    private AuthenticationService authenticationService;
-    private PasswordEncoder passwordEncoder;
+    private final JwtTokenService tokenService;
+    private final AuthenticationService authenticationService;
+    private final PasswordEncoder passwordEncoder;
 
     public JwtAuthenticationController(JwtTokenService tokenService,
                                        AuthenticationService authenticationService,
                                        PasswordEncoder passwordEncoder) {
-        this.tokenService  = tokenService;
+        this.tokenService = tokenService;
         this.authenticationService = authenticationService;
         this.passwordEncoder = passwordEncoder;
     }
@@ -42,9 +38,11 @@ public class JwtAuthenticationController {
         log.info("logger: jwtTokenRequest: {}", jwtTokenRequest);
 
         CustomerDTO customerDTO = authenticationService.findByLoginId(jwtTokenRequest.get("loginId"));
-        UsernamePasswordAuthenticationToken authenticationToken = null;
+        if (customerDTO == null) {
+            return ResponseEntity.status(401).body(new JwtTokenResponse(null)); // Unauthorized
+        }
 
-        if (customerDTO != null && passwordEncoder.matches(jwtTokenRequest.get("pw"), customerDTO.getPw())) {
+        if (passwordEncoder.matches(jwtTokenRequest.get("pw"), customerDTO.getPw())) {
             List<GrantedAuthority> roles = new ArrayList<>();
             roles.add(new SimpleGrantedAuthority("일반회원"));
             CustomerDTO authCustomer =
@@ -54,20 +52,13 @@ public class JwtAuthenticationController {
                             .userName(customerDTO.getUserName())
                             .role(customerDTO.getRole()).build();
             log.info(authCustomer.toString());
-            authenticationToken =
+            UsernamePasswordAuthenticationToken authenticationToken =
                     new UsernamePasswordAuthenticationToken(authCustomer, null, roles);
-        }
 
-        String token = null;
-
-        // token이 있을때만 생성
-        if (authenticationToken != null) {
-            token = tokenService.generateToken(authenticationToken);
+            String token = tokenService.generateToken(authenticationToken);
             return ResponseEntity.ok(new JwtTokenResponse(token));
         } else {
-            return ResponseEntity.status(401).body(new JwtTokenResponse(null));
+            return ResponseEntity.status(401).body(new JwtTokenResponse(null)); // Unauthorized
         }
-
     }
-
 }

--- a/src/main/java/org/eDrink24/controller/login/JwtAuthenticationController.java
+++ b/src/main/java/org/eDrink24/controller/login/JwtAuthenticationController.java
@@ -59,11 +59,15 @@ public class JwtAuthenticationController {
         }
 
         String token = null;
+
         // token이 있을때만 생성
         if (authenticationToken != null) {
             token = tokenService.generateToken(authenticationToken);
+            return ResponseEntity.ok(new JwtTokenResponse(token));
+        } else {
+            return ResponseEntity.status(401).body(new JwtTokenResponse(null));
         }
-        return ResponseEntity.ok(new JwtTokenResponse(token));
+
     }
 
 }

--- a/src/main/java/org/eDrink24/service/customer/AuthenticationServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/customer/AuthenticationServiceImpl.java
@@ -22,6 +22,9 @@ public class AuthenticationServiceImpl implements AuthenticationService {
     public CustomerDTO findByLoginId(String loginId) {
         ModelMapper modelMapper = new ModelMapper();
         Customer customer = customerRepository.findByLoginId(loginId);
+        if (customer == null) {
+            throw new IllegalArgumentException("Customer not found for loginId: " + loginId);
+        }
         CustomerDTO customerDTO = modelMapper.map(customer, CustomerDTO.class);
         return customerDTO;
     }

--- a/src/main/java/org/eDrink24/service/customer/AuthenticationServiceImpl.java
+++ b/src/main/java/org/eDrink24/service/customer/AuthenticationServiceImpl.java
@@ -23,7 +23,7 @@ public class AuthenticationServiceImpl implements AuthenticationService {
         ModelMapper modelMapper = new ModelMapper();
         Customer customer = customerRepository.findByLoginId(loginId);
         if (customer == null) {
-            throw new IllegalArgumentException("Customer not found for loginId: " + loginId);
+            return null;
         }
         CustomerDTO customerDTO = modelMapper.map(customer, CustomerDTO.class);
         return customerDTO;


### PR DESCRIPTION
- 로그인에 실패해도 ok status를 클라이언트로 보냄
- JwtAuthenticationController.java의 64~69번째 라인에 기존에 ok로 보내주던 return을 token이 null이면 401 NoAuthorized를 보내도록 함
- loginId로 AuthenticationServiceImpl.java의 findByLoginId() 메서드에서 해당 customer를 찾지못하면 IllegalException발생
	- 못받아오면 null 리턴 => 클라이언트에 401 stauts 전송