### PR TITLE
fix2 장바구니 목록에서 categoey2 삭제

### DIFF
--- a/src/main/java/org/eDrink24/config/OrderMapper.java
+++ b/src/main/java/org/eDrink24/config/OrderMapper.java
@@ -3,11 +3,8 @@ package org.eDrink24.config;
 import org.apache.ibatis.annotations.Mapper;
 import org.eDrink24.dto.basket.BasketDTO;
 import org.eDrink24.dto.order.OrderDTO;
-import org.eDrink24.dto.product.DetailProductDTO;
-import org.eDrink24.dto.product.ProductDTO;
-
 import java.util.List;
-import java.util.Map;
+
 
 
 @Mapper

--- a/src/main/java/org/eDrink24/dto/basket/BasketDTO.java
+++ b/src/main/java/org/eDrink24/dto/basket/BasketDTO.java
@@ -19,6 +19,7 @@ public class BasketDTO {
     private Integer basketId;
     private Integer userId;
     private Integer productId;
+    private String defaultImage;
     private String productName;
     private Integer price;
     private Integer basketQuantity;

--- a/src/main/java/org/eDrink24/dto/basket/BasketJoinProductDTO.java
+++ b/src/main/java/org/eDrink24/dto/basket/BasketJoinProductDTO.java
@@ -14,7 +14,6 @@ import org.apache.ibatis.type.Alias;
 public class BasketJoinProductDTO {
 
     private String productName;
-    private String category2;
     private Integer price;
     private String defaultImage;
     private Integer basketQuantity;

--- a/src/main/resources/config/BasketMapper.xml
+++ b/src/main/resources/config/BasketMapper.xml
@@ -11,7 +11,7 @@
     </insert>
 
     <select id="showProductInBasket" parameterType="Integer" resultType="BasketJoinProductDTO">
-        select p.productName, p.category2, p.price, p.defaultImage, b.basketQuantity
+        select p.productName, p.price, p.defaultImage, b.basketQuantity
         from basket b join product p on p.productId = b.productId
         where b.userId=#{userId}
     </select>

--- a/src/main/resources/config/OrderMapper.xml
+++ b/src/main/resources/config/OrderMapper.xml
@@ -10,6 +10,7 @@
       select
         BASKET.basketId,
         BASKET.userId,
+        Product.defaultImage,
         Product.productName,
         Product.price,
         BASKET.productId,


### PR DESCRIPTION
fix 장바구니에 담긴 목록 가져올 때 제품사진 추가해서 가져오기

- 장바구니 목록에서 productName에 레드와인인지 화이트와인인지가 포함되어 있어서 category2를 중복해서 보여주지 않아도 될꺼같아서 삭제

- 장바구니에서 주문하기 버튼을 클릭하였을 때 주문목록에 장바구니에 있던 목록들이 넘어가는데 이때 제품사진을 추가해서 넘겨줌.